### PR TITLE
Added post management command.

### DIFF
--- a/friskby/GW/friskby_gw.py
+++ b/friskby/GW/friskby_gw.py
@@ -36,7 +36,7 @@ class FriskBySensor(FriskByHttp):
     def __init__(self , values , url = ROOT_URL , key = None):
         super(FriskBySensor , self).__init__( url )
         sensor_type = values["sensor_type"]
-        self.id = values["id"]
+        self.id = values["sensor_id"]
         self.min_value = sensor_type["min_value"]
         self.max_value = sensor_type["max_value"]
         self.post_key = key

--- a/sensor/management/commands/post.py
+++ b/sensor/management/commands/post.py
@@ -1,0 +1,52 @@
+import sys
+import requests
+import json
+import httplib
+
+from django.core.management.base import BaseCommand, CommandError
+from sensor.models import *
+from ._sample import sample
+from ._sensor_list import sensor_list
+    
+class Command(BaseCommand):
+    help = ""
+    
+
+    def add_arguments( self, parser):
+        parser.add_argument('sensor')
+        parser.add_argument('value')
+        parser.add_argument('--url')
+        parser.add_argument('--key')
+
+
+    def handle(self , *args , **options):
+        sensor_id = options["sensor"]
+        value = float( options["value"] )
+        
+        url = options["url"]
+        if url is None:
+            url = "http://127.0.0.1:8000"
+
+        key = options["key"]
+        if key is None:
+            sensor = Sensor.objects.get( sensor_id = sensor_id )
+            key = str(sensor.parent_device.post_key.external_key)
+
+        data = {"sensorid" : sensor_id , 
+                "value" : value, 
+                "timestamp" : TimeStamp.create( ),
+                "key" : key}
+
+        full_url = "%s/sensor/api/reading/" % url
+        print("Posting to: %s" % full_url)
+        try:
+            respons = requests.post( full_url, 
+                                     headers = {'Content-Type': 'application/json'},
+                                     data = json.dumps(data))
+        except:
+            sys.exit("Exception raised when posting")
+
+        status_code = respons.status_code
+        print("%d : %s" % (status_code, httplib.responses[ status_code ]))
+        
+

--- a/sensor/tests/test_command_post.py
+++ b/sensor/tests/test_command_post.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+from sensor.management.commands.post import Command as PostCommand
+from .context import TestContext
+
+
+class CommandPostTest(TestCase):
+    
+    def test_post(self):
+        cmd = PostCommand( )
+        


### PR DESCRIPTION
Added simple command so that you can do:
```bash
./manage.py post SensorID $Value
```
to post a value to the server. Will by default post to localhost (i.e. the dev server must run in another shell), but you can pass the `--url` switch to post elsewhere.