### PR TITLE
Sorted devices

### DIFF
--- a/friskby/static/css/friskby.css
+++ b/friskby/static/css/friskby.css
@@ -66,3 +66,7 @@ div.header h1 {
     height: 500px;
     width: 95%;
 }
+
+table .valuecol {
+    text-align: right;
+}

--- a/friskby/templates/friskby/quick.html
+++ b/friskby/templates/friskby/quick.html
@@ -65,7 +65,7 @@
   <table class="pure-table">
     <tr><th>Location</th><th>{{pretty_sensor}}</th><th>Last update</th></tr>
     {% for d in device_rows %}
-    <tr><td>{{d.locname}}</td><td>{{d.last}}</td><td>{{d.time}}</td></tr>
+    <tr><td>{{d.locname}}</td><td class="valuecol">{{d.last}}</td><td>{{d.time}}</td></tr>
     {% endfor %}
   </table>
 </div>

--- a/friskby/views/quick.py
+++ b/friskby/views/quick.py
@@ -109,6 +109,12 @@ class Quick(View):
                 'isotime': time}
             device_rows.append(row)
 
+        # this sorts the devices lexicographically, but BG_XXX devices last
+        cmp_ln = lambda x: x['locname']
+        cmp_id = lambda x: 1 if x['id'][:2] == 'BG' else 0
+        device_rows = sorted(device_rows, key=cmp_ln)
+        device_rows = sorted(device_rows, key=cmp_id)
+
         algo_end = TimeStamp.now()
         algo_delta = algo_end - algo_start
         print('total time used: %.2f sec' % algo_delta.total_seconds())


### PR DESCRIPTION
Sort devices lexicographically by `FriskPI` sensors before `BG` sensors.

Fixes #164 

Second commit right aligns values in status column.