### PR TITLE
deleted pmselect javascript

### DIFF
--- a/friskby/templates/friskby/quick.html
+++ b/friskby/templates/friskby/quick.html
@@ -20,11 +20,6 @@
       map.onSelect(function(id) {
         chart.select(id);
       });
-      document.getElementById("pmselect").onchange = function(e) {
-        var listname = this.value + "list";
-        chart.showDataFor(values, listname);
-        map.showDataFor(values, listname, timestamp);
-      };
       document.getElementById("slider").oninput = function(e) {
         var val = this.value;
         var n = Math.floor((values[0]["datalist"].length - 1) * val);


### PR DESCRIPTION
Fixes #160 

I'm not sure why the code was there in the first place, perhaps to switch sensor types by javascript, but now that's no longer needed.

@mortalisk If this shouldn't be deleted after all, let me know and I'll revert.