### PR TITLE
Added manage command to clean test data

### DIFF
--- a/sensor/management/commands/_sample.py
+++ b/sensor/management/commands/_sample.py
@@ -18,7 +18,8 @@ def sample(sensor , n):
     data = arma( n )
     for d in data:
         ts += datetime.timedelta( seconds = 600 )
-        rd = RawData.objects.create( sensor_id = sensor.sensor_id,
+        rd = RawData.objects.create( s_id = sensor,
+                                     sensor_id = sensor.sensor_id,
                                      timestamp_data = ts,
                                      value = d)
 

--- a/sensor/management/commands/clean_test.py
+++ b/sensor/management/commands/clean_test.py
@@ -1,0 +1,20 @@
+import sys
+import datetime
+from django.core.management.base import BaseCommand, CommandError
+from sensor.models import *
+
+class Command(BaseCommand):
+    help = """Will remove all test entries from RawData table."""
+
+
+    def handle(self, *args, **options):
+        try:
+            test_dev = Device.objects.get( pk = "FriskPITest" )
+        except Device.DoesNotExist:
+            return
+            
+        time_limit = TimeStamp.now() - datetime.timedelta( days = 1 )
+        sensor_list = test_dev.sensorList()
+        rd = RawData.objects.filter( s_id__in = test_dev.sensorList( ) , timestamp_data__lt = time_limit)
+        rd.delete( )
+        

--- a/sensor/models.py
+++ b/sensor/models.py
@@ -218,7 +218,7 @@ class RawData(Model):
 
         ts = TimeStamp.parse_datetime(data["timestamp"])
         if ts is None:
-            return "Error: invalid timestamp - expected: YYYY-MM-DDTHH:MM:SS+zz"
+            return "Error: invalid timestamp - expected: %s" % TimeStamp.DATETIME_FORMAT
 
         return None
 


### PR DESCRIPTION
When this is merged we can add a scheduled command in heroku - something like:

`python ./manage.py clean_test`  to be run e.g. every 24H.