### PR TITLE
Discussion / suggestion

### DIFF
--- a/sensor/api/api_views.py
+++ b/sensor/api/api_views.py
@@ -233,8 +233,8 @@ class ReadingView(APIView):
     def post(self , request , format = None):
         try:
             raw_data = RawData.create( request.data )
-        except ValueError:
-            return Response(RawData.error( request.data ) , status = status.HTTP_400_BAD_REQUEST )
+        except ValueError as e:
+            return Response(str(e) , status = status.HTTP_400_BAD_REQUEST )
         
         rd        = raw_data[0]
         sensorid  = rd.sensor_id

--- a/sensor/tests/context.py
+++ b/sensor/tests/context.py
@@ -28,17 +28,37 @@ class TestContext(object):
                                                owner = self.user,
                                                post_key = self.key )
 
-        self.mtype = MeasurementType.objects.create( name = "Temperature" )
+        self.mtype_temp = MeasurementType.objects.create( name = "Temperature" )
+        self.mtype_hum = MeasurementType.objects.create( name = "Hum" )
+        self.mtype_pressure = MeasurementType.objects.create( name = "Press" )
         self.raw_data = DataType.objects.get( pk = "RAWDATA" )
         self.test_data = DataType.objects.get( pk = "TEST" )
 
         self.sensor_type_temp = SensorType.objects.create( product_name = "XX12762 Turbo",
-                                                           measurement_type = self.mtype,
+                                                           measurement_type = self.mtype_temp,
                                                            short_description = "Temp",
                                                            description = "Measurement of temperature",
                                                            unit = "Degree celcius",
                                                            min_value = 0,
                                                            max_value = 100)
+
+        self.sensor_type_hum = SensorType.objects.create( product_name = "XX12762 Turbo",
+                                                          measurement_type = self.mtype_hum,
+                                                          short_description = "Temp",
+                                                          description = "Measurement of temperature",
+                                                          unit = "Degree celcius",
+                                                          min_value = 0,
+                                                          max_value = 100)
+
+
+        self.sensor_type_pressure = SensorType.objects.create( product_name = "XX12762 Turbo",
+                                                               measurement_type = self.mtype_pressure,
+                                                               short_description = "Temp",
+                                                               description = "Measurement of temperature",
+                                                               unit = "Degree celcius",
+                                                               min_value = 0,
+                                                               max_value = 100)
+
 
         self.temp_sensor = Sensor.objects.create( sensor_id = "TEMP:XX",
                                                   s_id = abs(hash("TEMP:XX")),
@@ -51,14 +71,14 @@ class TestContext(object):
                                                  description = "Measurement humidity",
                                                  data_type = self.raw_data ,
                                                  parent_device = self.dev,
-                                                 sensor_type = self.sensor_type_temp)
+                                                 sensor_type = self.sensor_type_hum)
 
         self.loc0_sensor = Sensor.objects.create( sensor_id = "NO_LOC:XX",
                                                   s_id = abs(hash("NO_LOC:XX")),
-                                                  description = "Measurement humidity",
+                                                  description = "Measurement pressure",
                                                   data_type = self.raw_data ,
                                                   parent_device = self.dev_loc0,
-                                                  sensor_type = self.sensor_type_temp)
+                                                  sensor_type = self.sensor_type_pressure)
 
 
         self.test_user_passwd = get_random_string( length = 10 ),

--- a/sensor/tests/test_api_data.py
+++ b/sensor/tests/test_api_data.py
@@ -108,6 +108,35 @@ class Readingtest(TestCase):
         response = client.post( url , data = json.dumps( data ) , content_type = "application/json")
         self.assertEqual( response.status_code , status.HTTP_400_BAD_REQUEST , response.data)
 
+        # Valid - using id=(device_id, measurement_type) instead of sensor_id
+        data = {"id" : ( self.context.dev.id , self.context.mtype_temp.name),
+                "value" : "50" , "timestamp" : "2015-10-10T12:12:00+01", "key" : self.context.external_key}
+        string_data = json.dumps( data )
+        response = client.post( url , data = json.dumps( data ) , content_type = "application/json")
+        self.assertEqual( response.status_code , status.HTTP_201_CREATED , response.data)
+
+        # Bad request - invalid device id
+        data = {"id" : ( "INVALID_ID" , self.context.mtype_temp.name),
+                "value" : "50" , "timestamp" : "2015-10-10T12:12:00+01", "key" : self.context.external_key}
+        string_data = json.dumps( data )
+        response = client.post( url , data = json.dumps( data ) , content_type = "application/json")
+        self.assertEqual( response.status_code , status.HTTP_400_BAD_REQUEST , response.data )
+
+        # Bad request - invalid mtype
+        data = {"id" : ( self.context.dev.id , "INVALID"),
+                "value" : "50" , "timestamp" : "2015-10-10T12:12:00+01", "key" : self.context.external_key}
+        string_data = json.dumps( data )
+        response = client.post( url , data = json.dumps( data ) , content_type = "application/json")
+        self.assertEqual( response.status_code , status.HTTP_400_BAD_REQUEST , response.data)
+
+
+        # Bad request - invalid id form
+        data = {"id" : self.context.dev.id,
+                "value" : "50" , "timestamp" : "2015-10-10T12:12:00+01", "key" : self.context.external_key}
+        string_data = json.dumps( data )
+        response = client.post( url , data = json.dumps( data ) , content_type = "application/json")
+        self.assertEqual( response.status_code , status.HTTP_400_BAD_REQUEST , response.data)
+
 
 
     def test_get(self):

--- a/sensor/tests/test_api_endpoint.py
+++ b/sensor/tests/test_api_endpoint.py
@@ -133,7 +133,7 @@ class SensorTypeTest(TestCase):
         response = client.get("/sensor/api/sensortype/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = json.loads(response.content)
-        self.assertEqual(len(data), 1)
+        self.assertEqual(len(data), 3)
 
         response = client.get("/sensor/api/sensortype/%d/" % self.context.sensor_type_temp.id)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
I feel there is "something rotten" in the datamodel with (at least) the concepts of Device, Sensor, MeasurementType and SensorType. In particular the pattern that sensors have id as:

```python
sensor_id = "%s_%s" % (device_id , measurement_type)
```
has become a hard-wired assumption which is not reflected anywhere in the datamodel - bad bad. It is not clear to me what is the Right&trade; way to improve on this, but as I see it the fundamental entities are:

**Devices**: These have a physical location, an owner and so on.

**MeasurementTypes**: I.e. are we focusing on `PM10` or `PM25` - or temperature for that matter (maybe **SensorType** actually is a better choice?)

Based on that assumption I have changed the post code to accept `id = (device_id, mtype)` instead of `sensor_id`. Observe that this is very much just a first step:

1. The code still accepts `sensor_id` in the `POST` payload, i..e there is no need to immediately update the client.

2. The `(dev_id, mtype)` pair is immediately converted to a sensor_id - if we decide to go along this way we should of course let the change permeate deeper in the code.

I guess the current datamodel is the *fully flexible* solution, but currently we do *not* use that flexibility, and instead there are other parts of the code which actually assume conventions like the mentioned structure of the `sensor_id` - iff we do not foresee that we will ever use the full flexibility it might be wise limit the flexibility somewhat and embed those constraints explicitly in the datamodel?
