### PR TITLE
Added Location.create

### DIFF
--- a/api_key/models.py
+++ b/api_key/models.py
@@ -1,12 +1,10 @@
 import uuid
 from django.db.models import *
 
-
 class ApiKey( Model ):
     external_key = UUIDField( default=uuid.uuid4 , unique = True )
     description = CharField( max_length = 256 )
 
-    
     def __unicode__(self):
         return "%s: %s" % ( self.description , str(self.external_key))
 
@@ -23,9 +21,8 @@ class ApiKey( Model ):
                 api_key = ApiKey.objects.get( external_key = external_uuid )
             except ApiKey.DoesNotExist:
                 valid = False
-        
-        return valid
 
+        return valid
 
 
     def access(self , external_key):
@@ -33,8 +30,7 @@ class ApiKey( Model ):
             return True
         else:
             return False
-            
-            
+
     def reset(self):
         self.external_key = uuid.uuid4( )
         self.save( )

--- a/sensor/api/api_views.py
+++ b/sensor/api/api_views.py
@@ -1,7 +1,7 @@
 import json
 import requests
 import time
-import datetime 
+import datetime
 
 from django.conf import settings
 from django.http import QueryDict
@@ -20,18 +20,18 @@ import sensor.models as models
 from sensor.api.serializers import *
 from sensor.api.info_serializers import *
 
-        
+
 
 class MeasurementTypeListView(generics.ListCreateAPIView):
     queryset = models.MeasurementType.objects.all()
     serializer_class = MeasurementTypeSerializer
-    
 
 
-class MeasurementTypeView(generics.RetrieveAPIView):    
+
+class MeasurementTypeView(generics.RetrieveAPIView):
     queryset = models.MeasurementType.objects.all()
     serializer_class = MeasurementTypeSerializer
-    
+
 
 #################################################################
 
@@ -39,15 +39,15 @@ class MeasurementTypeView(generics.RetrieveAPIView):
 class DeviceTypeListView(generics.ListCreateAPIView):
     queryset = models.DeviceType.objects.all()
     serializer_class = DeviceTypeSerializer
-    
 
-class DeviceTypeView(generics.RetrieveAPIView):    
+
+class DeviceTypeView(generics.RetrieveAPIView):
     queryset = models.DeviceType.objects.all()
     serializer_class = DeviceTypeSerializer
 
 #################################################################
-    
-class DeviceView(View):    
+
+class DeviceView(View):
     #queryset = models.Device.objects.all()
     #serializer_class = DeviceSerializer
 
@@ -61,7 +61,7 @@ class DeviceView(View):
         else:
             return self.get_list( request )
 
-        
+
     def get_list(self, request):
         data = []
         for dev in models.Device.objects.all():
@@ -69,12 +69,12 @@ class DeviceView(View):
             if dev.location:
                 location_name = dev.location.name
             data.append( (dev.id , location_name ))
-            
+
         return JsonResponse( data , status = status.HTTP_200_OK , safe = False )
-    
 
 
-    
+
+
     def get_detail(self , request , device_id, key):
         try:
             device = Device.objects.get( pk = device_id )
@@ -91,7 +91,7 @@ class DeviceView(View):
 
         return JsonResponse( serial.get_data( ) )
 
-    
+
 
     def put(self , request , *args, **kwargs):
         device_id = kwargs["pk"]
@@ -103,22 +103,22 @@ class DeviceView(View):
         data = json.loads( request.body )
         if "key" in data:
             if not device.valid_post_key( data["key"] ):
-                return HttpResponse("Invalid key: %s for device:%s " % (data["key"], device_id) , 
+                return HttpResponse("Invalid key: %s for device:%s " % (data["key"], device_id) ,
                                     status = status.HTTP_403_FORBIDDEN )
         else:
-            return HttpResponse("Missing key for device: %s" % device_id , 
+            return HttpResponse("Missing key for device: %s" % device_id ,
                                 status = status.HTTP_403_FORBIDDEN )
-            
+
         if "git_ref" in data:
             device.client_version = data["git_ref"]
             device.save( )
             return HttpResponse("Client version set to: %s" % device.client_version, status = status.HTTP_200_OK )
         else:
             return HttpResponse("Empty payload?" , status = status.HTTP_204_NO_CONTENT)
-            
-            
 
-        
+
+
+
 
 
 
@@ -127,9 +127,9 @@ class DeviceView(View):
 class LocationListView(generics.ListCreateAPIView):
     queryset = models.Location.objects.all()
     serializer_class = LocationSerializer
-    
 
-class LocationView(generics.RetrieveAPIView):    
+
+class LocationView(generics.RetrieveAPIView):
     queryset = models.Location.objects.all()
     serializer_class = LocationSerializer
 
@@ -139,9 +139,9 @@ class LocationView(generics.RetrieveAPIView):
 class DataTypeListView(generics.ListCreateAPIView):
     queryset = models.DataType.objects.all()
     serializer_class = DataTypeSerializer
-    
 
-class DataTypeView(generics.RetrieveAPIView):    
+
+class DataTypeView(generics.RetrieveAPIView):
     queryset = models.DataType.objects.all()
     serializer_class = DataTypeSerializer
 
@@ -152,9 +152,9 @@ class DataTypeView(generics.RetrieveAPIView):
 class TimeStampListView(generics.ListCreateAPIView):
     queryset = models.TimeStamp.objects.all()
     serializer_class = TimeStampSerializer
-    
 
-class TimeStampView(generics.RetrieveAPIView):    
+
+class TimeStampView(generics.RetrieveAPIView):
     queryset = models.TimeStamp.objects.all()
     serializer_class = TimeStampSerializer
 
@@ -165,9 +165,9 @@ class TimeStampView(generics.RetrieveAPIView):
 class SensorListView(generics.ListCreateAPIView):
     queryset = models.Sensor.objects.all()
     serializer_class = SensorSerializer
-    
 
-class SensorView(generics.RetrieveAPIView):    
+
+class SensorView(generics.RetrieveAPIView):
     queryset = models.Sensor.objects.all()
     serializer_class = SensorSerializer
 
@@ -177,9 +177,9 @@ class SensorView(generics.RetrieveAPIView):
 class SensorTypeListView(generics.ListCreateAPIView):
     queryset = models.SensorType.objects.all()
     serializer_class = SensorTypeSerializer
-    
 
-class SensorTypeView(generics.RetrieveAPIView):    
+
+class SensorTypeView(generics.RetrieveAPIView):
     queryset = models.SensorType.objects.all()
     serializer_class = SensorTypeSerializer
 
@@ -196,18 +196,18 @@ class SensorInfoView(APIView):
                 sensor_list = [ models.Sensor.objects.get( sensor_id = sensor_id ) ]
             except models.Sensor.DoesNotExist:
                 return Response("The sensorID:%s is not found" % sensor_id , status.HTTP_404_NOT_FOUND)
-            
+
         result = []
         for sensor in sensor_list:
             serialized = SensorInfoSerializer( sensor )
             data = serialized.data
-            
+
             result.append( data )
-            
+
         if sensor_id is None:
-            return Response( result , status = status.HTTP_200_OK ) 
+            return Response( result , status = status.HTTP_200_OK )
         else:
-            return Response( result[0] , status = status.HTTP_200_OK ) 
+            return Response( result[0] , status = status.HTTP_200_OK )
 
 
 class ReadingView(APIView):
@@ -218,7 +218,7 @@ class ReadingView(APIView):
 #        else:
 #            return (status.HTTP_400_BAD_REQUEST , "Missing 'sensorid' field in payload")
 #
-#                    
+#
 #        if "value" in data:
 #            value = data["value"]
 #        else:
@@ -235,10 +235,10 @@ class ReadingView(APIView):
 #            if sensor.parent_device.location is None:
 #                if not "location" in data:
 #                    return (status.HTTP_400_BAD_REQUEST , "Sensor:%s does not have location - must supply in post" % sensorid)
-#                        
+#
 #        except models.Sensor.DoesNotExist:
 #            return (status.HTTP_404_NOT_FOUND , "The sensorID:%s is not found" % sensorid)
-#            
+#
 #        return (True , "")
 
 
@@ -248,7 +248,7 @@ class ReadingView(APIView):
             raw_data = RawData.create( request.data )
         except ValueError as e:
             return Response(str(e) , status = status.HTTP_400_BAD_REQUEST )
-        
+
         rd        = raw_data[0]
         value     = rd.value
         timestamp = rd.timestamp_data
@@ -263,7 +263,7 @@ class ReadingView(APIView):
             if not "location" in request.data:
                 return Response("Sensor:%s does not have location - must supply in post" % rd.sensor , status.HTTP_400_BAD_REQUEST)
             location = request.data["location"]
-                    
+
 
         if sensor.on_line:
             sensor.last_value = value
@@ -277,13 +277,13 @@ class ReadingView(APIView):
             return Response(1 , status.HTTP_201_CREATED)
         else:
             return Response("Sensor: %s is offline - rawdata created and stored" % rd.sensor_id )
-            
-        
+
+
 
     def get(self , request , sensor_id = None):
         if sensor_id is None:
             return Response("Must supply sensorid when querying" , status = status.HTTP_400_BAD_REQUEST )
-            
+
         try:
             if "num" in request.GET:
                 num = int(request.GET["num"])
@@ -300,8 +300,8 @@ class ReadingView(APIView):
             return Response(ts , status = status.HTTP_200_OK )
         except models.Sensor.DoesNotExist:
             return Response("No such sensor:%s" % sensor_id , status = status.HTTP_404_NOT_FOUND )
-            
-        
+
+
 
 
 
@@ -345,14 +345,14 @@ class CurrentValueView(APIView):
                 sensor_list = models.Sensor.objects.all( )
             else:
                 sensor_list = models.Sensor.objects.filter( sensor_type__measurement_type = mtype )
-            
+
             data = []
             for sensor in sensor_list:
-                sensor_data = sensor.get_current( timeout ) 
+                sensor_data = sensor.get_current( timeout )
                 if sensor_data is None:
                     sensor_data = {"sensorid" : sensor.sensor_id }
                 data.append( sensor_data )
-                
+
             return Response( data )
 
 
@@ -368,13 +368,13 @@ class RawDataView(APIView):
         data = []
         for row in query:
             data.append( (row.timestamp_data , row.value ))
-        
+
         return Response( data )
-                                       
+
 #################################################################
 
-class ClientLogView(APIView):    
-    
+class ClientLogView(APIView):
+
     def post(self , request):
         data = request.data
         try:
@@ -383,7 +383,7 @@ class ClientLogView(APIView):
             msg = data["msg"]
         except KeyError:
             return Response("Invalid log data" , status = 400)
-            
+
         try:
             device = Device.objects.get( pk = device_id )
         except Device.DoesNotExist:
@@ -399,8 +399,8 @@ class ClientLogView(APIView):
             return Response(1 , status.HTTP_201_CREATED )
         else:
             return Response("Invalid key :%s" % api_key , status = 403)
-    
-   
+
+
     def get(self, request):
         data = []
         for log_entry in ClientLog.objects.filter( ):
@@ -415,4 +415,3 @@ class ClientLogView(APIView):
             data.append( node )
 
         return Response( data )
-        

--- a/sensor/api/urls.py
+++ b/sensor/api/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     url(r'^location/$' , LocationListView.as_view()),
     url(r'^location/(?P<pk>[0-9]+)/$' , LocationView.as_view()),
     url(r'^location/create/(?P<pk>%s)/$' % models.Device.IDPattern,
-        LocationCreator.as_view(), name="view.location.creator"),
+        LocationCreator.as_view(), name="sensor.api.location.create"),
     #
     url(r'^data_type/$' , DataTypeListView.as_view()),
     url(r'^data_type/(?P<pk>[0-9]+)/$' , DataTypeView.as_view()),

--- a/sensor/api/urls.py
+++ b/sensor/api/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
     #
     url(r'^location/$' , LocationListView.as_view()),
     url(r'^location/(?P<pk>[0-9]+)/$' , LocationView.as_view()),
+    url(r'^location/create/(?P<pk>%s)/$' % models.Device.IDPattern,
+        LocationCreator.as_view(), name="view.location.creator"),
     #
     url(r'^data_type/$' , DataTypeListView.as_view()),
     url(r'^data_type/(?P<pk>[0-9]+)/$' , DataTypeView.as_view()),

--- a/sensor/models.py
+++ b/sensor/models.py
@@ -29,6 +29,13 @@ class Location(Model):
     def __unicode__(self):
         return self.name
 
+    @classmethod
+    def create(cls, data):
+        altitude = data.get('altitude', 0)
+        return Location.objects.create(longitude=data['longitude'],
+                                       latitude=data['latitude'],
+                                       altitude=altitude,
+                                       name=data['name'])
 
 
 class DeviceType(Model):

--- a/sensor/tests/test_location.py
+++ b/sensor/tests/test_location.py
@@ -1,0 +1,120 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from sensor.models import Device
+from .context import TestContext
+from api_key.models import ApiKey
+
+
+class LocationTest(TestCase):
+
+    def setUp(self):
+        self.context = TestContext()
+        self.client = Client()
+        self.dev_id = self.context.dev.id
+        self.url = reverse("sensor.api.location.create",
+                           kwargs={'pk': self.dev_id})
+        self.key = str(self.context.dev.post_key.external_key)
+        self.name, self.lat, self.lon, self.alt = 'Planet Hoth', 60.588, 7.48, 1222
+
+    def test_get_location(self):
+        device = Device.objects.get(pk=self.context.dev.id)
+        # name = "Ulriken", latitude = 200, longitude = 120, altitude = 600
+        self.assertEqual('Ulriken', device.location.name)
+        self.assertEqual(200, device.location.latitude)
+        self.assertEqual(120, device.location.longitude)
+        self.assertEqual(600, device.location.altitude)
+
+    def _assert_error_msg(self, err, msg):
+        """Asserts msg in err.message"""
+        self.assertIn(msg, err.message)
+
+    def test_create_location_key_issues(self):
+        with self.assertRaises(KeyError) as ctx:
+            self.client.get(self.url)
+        self._assert_error_msg(ctx.exception, 'Missing API-key')
+
+        with self.assertRaises(KeyError) as ctx:
+            data = {'key': 'no-such-key'}
+            self.client.get(self.url, data=data)
+        self._assert_error_msg(ctx.exception, 'Invalid')
+
+        other_existing_key = ApiKey.objects.create(description="Newerkey")
+        with self.assertRaises(KeyError) as ctx:
+            data = {'key': other_existing_key.external_key}
+            self.client.get(self.url, data=data)
+        self._assert_error_msg(ctx.exception, 'Invalid')
+
+
+    def test_create_location_missing_fields(self):
+        with self.assertRaises(KeyError) as ctx:  # missing latitude
+            data = {'key': self.key, 'longitude': self.lon, 'name': self.name}
+            self.client.get(self.url, data=data)
+        self._assert_error_msg(ctx.exception, 'latitude')
+
+        with self.assertRaises(KeyError) as ctx:  # missing longitude
+            data = {'key': self.key, 'latitude': self.lat, 'name': self.name}
+            self.client.get(self.url, data=data)
+        self._assert_error_msg(ctx.exception, 'longitude')
+
+        with self.assertRaises(KeyError) as ctx:  # missing name
+            data = {'key': self.key, 'latitude': self.lat, 'longitude': self.lon}
+            self.client.get(self.url, data=data)
+        self._assert_error_msg(ctx.exception, 'name')
+
+    def test_wrong_type_lat(self):
+        data = {'key': self.key,
+                'latitude': 'fortysix',
+                'longitude': self.lon,
+                'name': self.name}
+        with self.assertRaises(ValueError):
+            self.client.get(self.url, data=data)
+
+    def test_wrong_type_lon(self):
+        data = {'key': self.key,
+                'latitude': self.lat,
+                'longitude': 'two',
+                'name': self.name}
+        with self.assertRaises(ValueError):
+            self.client.get(self.url, data=data)
+
+    def test_wrong_type_alt(self):
+        data = {'key': self.key,
+                'latitude': self.lat,
+                'longitude': self.lon,
+                'altitude': 'and',
+                'name': self.name}
+        with self.assertRaises(ValueError):
+            self.client.get(self.url, data=data)
+
+
+    def test_create_location(self):
+        data = {'key': self.key,
+                'latitude': self.lat,
+                'longitude': self.lon,
+                'name': self.name}
+        self.client.get(self.url, data=data)
+
+        device = Device.objects.get(pk=self.context.dev.id)
+        new_loc = device.location
+
+        self.assertEqual(self.lat, new_loc.latitude)
+        self.assertEqual(self.lon, new_loc.longitude)
+        self.assertEqual(self.name, new_loc.name)
+        self.assertEqual(0, new_loc.altitude)
+
+    def test_create_location_with_altitude(self):
+        data = {'key': self.key,
+                'latitude': self.lat,
+                'longitude': self.lon,
+                'altitude': self.alt,
+                'name': self.name}
+        self.client.get(self.url, data=data)
+
+        device = Device.objects.get(pk=self.context.dev.id)
+        new_loc = device.location
+
+        self.assertEqual(self.lat, new_loc.latitude)
+        self.assertEqual(self.lon, new_loc.longitude)
+        self.assertEqual(self.name, new_loc.name)
+        self.assertEqual(self.alt, new_loc.altitude)

--- a/sensor/view/urls.py
+++ b/sensor/view/urls.py
@@ -9,6 +9,3 @@ urlpatterns = [
     url(r'^device/(?P<pk>%s)/$' % models.Device.IDPattern, DeviceView.as_view() , name = "view.device.info"),
     url(r'^keys/$' , KeyView.as_view(), name = "key.view.main")
 ]
-    
-
-

--- a/sensor/view/views.py
+++ b/sensor/view/views.py
@@ -17,9 +17,8 @@ class MainView(View):
 
 
 class DeviceView(View):
-    
+
     def get(self, request, pk):
         device = get_object_or_404( Device, pk = pk)
         device_data = DeviceSerializer( data = device )
         return render( request , "sensor/device.html" , device_data.get_data( ))
-        


### PR DESCRIPTION
To assist end users in creating location and setting location to a certain device, we want:

`api/create_location/` with post `id=FriskPiXY, key=000123..., latitude=66.71, longitude=5.5, altitude=50, name=Minde`

to construct a new location with aforementioned values, and set device id `FriskPiXY` to have this location, give, of course, that device `FriskPiXY` is associated with the provided API key.

Goal: #205 
